### PR TITLE
Exit with failure code when CLI migration fails

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -63,6 +63,7 @@ function error(err) {
 	console.error();
 	console.error(chalk.gray(err.stack));
 	console.error();
+	process.exit(1);
 }
 
 const options = cli.flags;


### PR DESCRIPTION
When using the migratio CLI with automated deployment tools, it's necessary to exit the process with a failure code when a migration fails (e.g. to prevent deploying an application on migration failure).